### PR TITLE
Add step to install Markdown building requirements for docstrings.

### DIFF
--- a/.github/workflows/docstrings.yml
+++ b/.github/workflows/docstrings.yml
@@ -32,6 +32,7 @@ jobs:
       - name: covert notebooks
         run: |
           cd $GITHUB_WORKSPACE/external
+          pip install -r requirements_docs.txt
           python markdown_doc_builder.py
           mv $GITHUB_WORKSPACE/external/markdown/* $GITHUB_WORKSPACE/site/content/en/docs/Reference/
 

--- a/content/en/docs/Examples/Remote Datasets/Copernicus.md
+++ b/content/en/docs/Examples/Remote Datasets/Copernicus.md
@@ -1,0 +1,34 @@
+---
+title: "Copernicus"
+linkTitle: "Copernicus"
+weight: 6
+
+description: >
+Examples of access to Copernicus datasets via OPeNDAP.
+---
+
+# Intro
+Remote access to Copernicus Marine Environment Monitoring Service CMEMS datasets is enabled via [OPeNDAP](https://en.wikipedia.org/wiki/OPeNDAP) and [Pydap](https://github.com/pydap/pydap).
+
+OPeNDAP allows COAsT to stream data from Copernicus without downloading specific subsets or the dataset as a whole.
+
+In order to access CMEMS data, you must first [create an account](https://resources.marine.copernicus.eu/registration-form).
+
+After you have created your account, or if you already have one, a product ID can be selected from the [product catalogue](https://resources.marine.copernicus.eu/products).
+
+# Example
+```python
+from coast import Copernicus
+
+
+# Authenticate with Copernicus and select a database.
+database = Copernicus(USERNAME, PASSWORD, "nrt")
+
+# Instantiate a product with its ID
+forecast = database.get_product("global-analysis-forecast-phy-001-024")
+
+# Create a COAsT object with the relevant config file
+nemo_t = coast.Gridded(fn_data=forecast, config="./config/example_cmems_grid_t.json")
+
+# TODO: Do some sciency things with the dataset
+```

--- a/content/en/docs/Examples/Remote Datasets/index.md
+++ b/content/en/docs/Examples/Remote Datasets/index.md
@@ -1,0 +1,8 @@
+---
+title: "Remote Datasets"
+linkTitle: "Remote Datasets"
+date: 2022-06-20
+weight: 6
+description: >
+Example scripts for access to remote datasets.
+---


### PR DESCRIPTION
Depends on [COAsT#474](https://github.com/British-Oceanographic-Data-Centre/COAsT/pull/474).