### PR TITLE
action change

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -1,6 +1,7 @@
 name: hugo
 
 on:
+  workflow_dispatch:
   push:
     branches: [ master ]
 


### PR DESCRIPTION
allow manual runs of the workflow - seem that the pull request did count as a push to master. so i have added the workflow_dispatch event to allow maunal triggering of this action without the need to push a change to master (outside a PR)
- this is the link i followed 
https://stackoverflow.com/questions/58933155/manual-workflow-triggers-in-github-actions